### PR TITLE
better param checks for built-in value functions

### DIFF
--- a/examples/simple/simple.csproj
+++ b/examples/simple/simple.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="openCypherTranspiler.Common" Version="0.1.0" />
-    <PackageReference Include="openCypherTranspiler.openCypherParser" Version="0.1.0" />
-    <PackageReference Include="openCypherTranspiler.LogicalPlanner" Version="0.1.0" />
-    <PackageReference Include="openCypherTranspiler.SQLRenderer" Version="0.1.0" />
+    <PackageReference Include="openCypherTranspiler.Common" Version="0.1.1" />
+    <PackageReference Include="openCypherTranspiler.openCypherParser" Version="0.1.1" />
+    <PackageReference Include="openCypherTranspiler.LogicalPlanner" Version="0.1.1" />
+    <PackageReference Include="openCypherTranspiler.SQLRenderer" Version="0.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -18,7 +18,7 @@
     <PackageTags>openCypher transpiler graph C# .NET</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/openCypherTranspiler/tree/master/src/openCypherParser</RepositoryUrl>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Common/Utils/TypeHelper.cs
+++ b/src/Common/Utils/TypeHelper.cs
@@ -14,7 +14,7 @@ namespace openCypherTranspiler.Common.Utils
         /// <summary>
         /// Check if null value can be assigned
         /// E.g. IsNullableType(string) = true, IsNullableType(DateTime) = false
-        ///      IsNullableType(
+        ///      IsNullableType(System.Nullable<int>) = true
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>

--- a/src/LogicalPlanner/LogicalPlanner.csproj
+++ b/src/LogicalPlanner/LogicalPlanner.csproj
@@ -18,7 +18,7 @@
     <PackageTags>openCypher transpiler graph C# .NET</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/openCypherTranspiler/tree/master/src/LogicalPlanner</RepositoryUrl>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SQLRenderer/SQLRenderer.csproj
+++ b/src/SQLRenderer/SQLRenderer.csproj
@@ -18,7 +18,7 @@
     <PackageTags>openCypher transpiler graph C# .NET</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/openCypherTranspiler/tree/master/src/openCypherParser</RepositoryUrl>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openCypherParser/AST/Expressions/QueryExpressionFunction.cs
+++ b/src/openCypherParser/AST/Expressions/QueryExpressionFunction.cs
@@ -39,23 +39,23 @@ namespace openCypherTranspiler.openCypherParser.AST
         public override Type EvaluateType()
         {
             var innerType = InnerExpression.EvaluateType();
-            var isWrappedinNullable = TypeHelper.IsSystemNullableType(innerType);
+            var canBeNull = TypeHelper.CanAssignNullToType(innerType);
             switch (Function.FunctionName)
             {
                 case Common.Function.ToFloat:
-                    return isWrappedinNullable ? typeof(float?) : typeof(float);
+                    return canBeNull ? typeof(float?) : typeof(float);
                 case Common.Function.ToString:
                     return typeof(string);
                 case Common.Function.ToBoolean:
-                    return isWrappedinNullable ? typeof(bool?) : typeof(bool);
+                    return canBeNull ? typeof(bool?) : typeof(bool);
                 case Common.Function.ToInteger:
-                    return isWrappedinNullable ? typeof(int?) : typeof(int);
+                    return canBeNull ? typeof(int?) : typeof(int);
                 case Common.Function.ToDouble:
-                    return isWrappedinNullable ? typeof(long?) : typeof(long);
+                    return canBeNull ? typeof(long?) : typeof(long);
                 case Common.Function.ToLong:
-                    return isWrappedinNullable ? typeof(double?) : typeof(double);
+                    return canBeNull ? typeof(double?) : typeof(double);
                 case Common.Function.Not:
-                    return isWrappedinNullable ? typeof(bool?) : typeof(bool);
+                    return canBeNull ? typeof(bool?) : typeof(bool);
                 case Common.Function.StringContains:
                 case Common.Function.StringStartsWith:
                 case Common.Function.StringEndsWith:

--- a/src/openCypherParser/Common/Function.cs
+++ b/src/openCypherParser/Common/Function.cs
@@ -82,6 +82,26 @@ namespace openCypherTranspiler.openCypherParser.Common
             }
         }
 
+        private static void EnsureStringType(FunctionInfo info, Type type)
+        {
+            if (!(
+                type == typeof(string)
+                ))
+            {
+                throw new TranspilerNotSupportedException($"Function {info.FunctionName} parameter of type {type.Name}");
+            }
+        }
+
+        private static void EnsureLengthType(FunctionInfo info, Type type)
+        {
+            if (!(
+                type == typeof(int) || type == typeof(long)
+                ))
+            {
+                throw new TranspilerNotSupportedException($"Function {info.FunctionName} parameter of type {type.Name}");
+            }
+        }
+
         private static void EnsureBooleanType(FunctionInfo info, Type type)
         {
             if (!(
@@ -188,7 +208,11 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringStartsWith,
                     RequiredParameters = 2,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                        EnsureStringType(info, types.Skip(1).First());
+                    }
                 }
             },
             { "stringendswith",  new FunctionInfo()
@@ -196,7 +220,11 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringEndsWith,
                     RequiredParameters = 2,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                        EnsureStringType(info, types.Skip(1).First());
+                    }
                 }
             },
             { "stringcontains",  new FunctionInfo()
@@ -204,7 +232,11 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringContains,
                     RequiredParameters = 2,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                        EnsureStringType(info, types.Skip(1).First());
+                    }
                 }
             },
             { "isnull",  new FunctionInfo()
@@ -228,7 +260,11 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringLeft,
                     RequiredParameters = 2,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                        EnsureLengthType(info, types.Skip(1).First());
+                    }
                 }
             },
             { "right", new FunctionInfo()
@@ -236,7 +272,11 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringRight,
                     RequiredParameters = 2,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                        EnsureLengthType(info, types.Skip(1).First());
+                    }
                 }
             },
             { "trim", new FunctionInfo()
@@ -244,7 +284,10 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringTrim,
                     RequiredParameters = 1,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                    }
                 }
             },
             { "ltrim", new FunctionInfo()
@@ -252,7 +295,10 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringLTrim,
                     RequiredParameters = 1,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                    }
                 }
             },
             { "rtrim", new FunctionInfo()
@@ -260,7 +306,10 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringRTrim,
                     RequiredParameters = 1,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                    }
                 }
             },
             { "toupper", new FunctionInfo()
@@ -268,7 +317,10 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringToUpper,
                     RequiredParameters = 1,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                    }
                 }
             },
             { "tolower", new FunctionInfo()
@@ -276,7 +328,10 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringToLower,
                     RequiredParameters = 1,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                    }
                 }
             },
             { "size", new FunctionInfo()
@@ -284,7 +339,10 @@ namespace openCypherTranspiler.openCypherParser.Common
                     FunctionName = Function.StringSize,
                     RequiredParameters = 1,
                     OptionalParameters = 0,
-                    ParameterChecker = EnsureParameterCountChecker
+                    ParameterChecker = (info, types) => {
+                        EnsureParameterCount(info, types.Count());
+                        EnsureStringType(info, types.First());
+                    }
                 }
             },
         };

--- a/src/openCypherParser/openCypherParser.csproj
+++ b/src/openCypherParser/openCypherParser.csproj
@@ -18,7 +18,7 @@
     <PackageTags>openCypher transpiler graph C# .NET</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/openCypherTranspiler/tree/master/src/openCypherParser</RepositoryUrl>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <NoWarn>CS3021</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
bump up package build ver
better param checks for the built-in functions
casting (parsing) a string to numeric now infers to nullable type (e.g. toFloat(str) -> float?)