### PR TITLE
minor fix an issue in label/type inference

### DIFF
--- a/src/openCypherParser/AST/MatchClause.cs
+++ b/src/openCypherParser/AST/MatchClause.cs
@@ -45,7 +45,7 @@ namespace openCypherTranspiler.openCypherParser.AST
         public IList<MatchPattern> MatchPatterns { get; set; }
 
         /// <summary>
-        /// Return a new MatchDataSource mirrors the old one but with anonymous entities filled with
+        /// Return a new MatchClause mirrors the old one but with anonymous entities filled with
         /// a place holder alias
         /// </summary>
         /// <param name="entity"></param>
@@ -60,8 +60,7 @@ namespace openCypherTranspiler.openCypherParser.AST
                 throw new TranspilerSyntaxErrorException($"Banned prefix for variable aliases: {anonVarPrefix}. Please consider a different prefix.");
             }
 
-            // creating a new DS with implied labels fixed up
-            var matchDsNew = new MatchClause()
+            return new MatchClause()
             {
                 MatchPatterns = MatchPatterns.Select(p => new MatchPattern(p.IsOptionalMatch, p.Select(e =>
                 {
@@ -71,8 +70,6 @@ namespace openCypherTranspiler.openCypherParser.AST
                     return entity;
                 }))).ToList()
             };
-
-            return matchDsNew;
         }
 
 

--- a/tests/openCypherParser.Test/OpenCypherParserTest.cs
+++ b/tests/openCypherParser.Test/OpenCypherParserTest.cs
@@ -192,6 +192,50 @@ RETURN toUpper(p.Name) as NameCapital, toLower(m.Title) as TitleLC
         }
 
         [TestMethod]
+        public void LabelTypeInferenceTest()
+        {
+            // Positive case already covered in many other tests
+            // Today we only support node label type to be specified
+            // implicitly when its aliases appeared more than once
+
+            // Negative case when the label cannot be inferred
+            {
+                var expectedExceptionThrown = false;
+                try
+                {
+                    var tree = RunQueryAndDumpTree(@"
+MATCH (p)-[:ACTED_IN]-(m:Movie)
+RETURN p.Name AS Name, m.Title as Title
+"
+                    );
+                }
+                catch (TranspilerSyntaxErrorException)
+                {
+                    expectedExceptionThrown = true;
+                }
+                Assert.IsTrue(expectedExceptionThrown);
+            }
+
+            // Negative case when the type cannot be inferred
+            {
+                var expectedExceptionThrown = false;
+                try
+                {
+                    var tree = RunQueryAndDumpTree(@"
+MATCH (p:Person)-[somewhatlinkedto]-(m:Movie)
+RETURN p.Name AS Name, m.Title as Title
+"
+                    );
+                }
+                catch (TranspilerSyntaxErrorException)
+                {
+                    expectedExceptionThrown = true;
+                }
+                Assert.IsTrue(expectedExceptionThrown);
+            }
+        }
+
+        [TestMethod]
         public void OtherWeirdSyntaxTest()
         {
             { 


### PR DESCRIPTION
There was a bug when we handle statement like:
`match (a:person)-[rel_alias]-(b:movie) ...`
The fix is for visitor to not do some unnecessary check and leave it to the end (after whole tree was parsed) then to process node label/relationship type which were not explicitly specified