### PR TITLE
bug fixes on field type propagation

### DIFF
--- a/src/Common/Exceptions/TranspilerBindingException.cs
+++ b/src/Common/Exceptions/TranspilerBindingException.cs
@@ -11,7 +11,7 @@ namespace openCypherTranspiler.Common.Exceptions
     public class TranspilerBindingException : TranspilerException
     {
         public TranspilerBindingException(string bindingErrorMsg) :
-            base($"Data binding error error: {bindingErrorMsg}")
+            base($"Data binding error: {bindingErrorMsg}")
         {
 
         }

--- a/src/LogicalPlanner/Logical/ProjectionOperator.cs
+++ b/src/LogicalPlanner/Logical/ProjectionOperator.cs
@@ -34,6 +34,9 @@ namespace openCypherTranspiler.LogicalPlanner
             // we calculate the data type of all the fields in the output schema
             // using type evaluation method on the QueryExpression
 
+            // Map from out_alias to { projection_expression, 
+            // e.g.: (a.b + c) AS d
+            //    "d" -> (<expression of a.b+c>, <d's field in OutputSchema>)
             var exprToOutputMap = ProjectionMap.ToDictionary(
                 kv => kv.Key, // key is output alias
                 kv => new { Expr = kv.Value, Field = OutputSchema.First(f => f.FieldAlias == kv.Key) } // value is the corresponding field object and expression
@@ -45,12 +48,19 @@ namespace openCypherTranspiler.LogicalPlanner
                     (map.Value.Expr.GetChildrenQueryExpressionType<QueryExpressionAggregationFunction>().Count() > 0);
 
                 var allPropertyReferences = map.Value.Expr.GetChildrenQueryExpressionType<QueryExpressionProperty>();
+
+                // update types for all QueryExpressionPropty object first based on InputSchema (so QueryExpression.EvaluteType() will work)
+                foreach (var prop in allPropertyReferences)
+                {
+                    UpdatePropertyBasedOnAliasFromInputSchema(prop);
+                }
+
+                // then, update the type in the OutputSchema
                 if (map.Value.Field is EntityField)
                 {
                     // This can only be direct exposure of entity (as opposed to deference of a particular property)
                     // We just copy of the fields that the entity can potentially be dereferenced
                     Debug.Assert(allPropertyReferences.Count() == 1);
-
                     var varName = allPropertyReferences.First().VariableName;
                     var matchInputField = InputSchema.First(f => f.FieldAlias == varName);
                     map.Value.Field.Copy(matchInputField);
@@ -60,58 +70,6 @@ namespace openCypherTranspiler.LogicalPlanner
                     // This can be a complex expression involve multiple field/column references
                     // We will compute the type of the expression
                     Debug.Assert(map.Value.Field is ValueField);
-
-                    // first of all, bind the type to the variable references
-                    foreach (var prop in allPropertyReferences)
-                    {
-                        var varName = prop.VariableName;
-                        var propName = prop.PropertyName;
-                        Debug.Assert(prop.VariableName != null);
-                        var matchedField = InputSchema.FirstOrDefault(f => f.FieldAlias == varName);
-
-                        if (matchedField == null)
-                        {
-                            throw new TranspilerBindingException($"Failed to find input matching field alias {varName}");
-                        }
-
-                        if (string.IsNullOrEmpty(propName))
-                        {
-                            // direct reference to an alias (value column or entity column)
-                            if (matchedField is ValueField)
-                            {
-                                prop.DataType = (matchedField as ValueField).FieldType;
-                            }
-                            else
-                            {
-                                // entity field reference in a single field expression
-                                // this is valid only in handful situations, such as Count(d), Count(distinct(d))
-                                // in such case, we populate the Entity object with correct entity type so that code generator can use it later
-                                Debug.Assert(matchedField is EntityField);
-                                var matchedEntity = matchedField as EntityField;
-                                prop.Entity = matchedEntity.Type == EntityField.EntityType.Node ?
-                                    new NodeEntity() { EntityName = matchedEntity.EntityName, Alias = matchedEntity.FieldAlias } as Entity:
-                                    new RelationshipEntity() { EntityName = matchedEntity.EntityName, Alias = matchedEntity.FieldAlias } as Entity;
-                            }
-                        }
-                        else
-                        {
-                            // property dereference of an entity column
-                            if (!(matchedField is EntityField))
-                            {
-                                throw new TranspilerBindingException($"Failed to dereference property {propName} for alias {varName}, which is not an alias of entity type as expected");
-                            }
-                            var entField = matchedField as EntityField;
-                            var entPropField = entField.EncapsulatedFields.FirstOrDefault(f => f.FieldAlias == propName);
-                            if (entPropField == null)
-                            {
-                                throw new TranspilerBindingException($"Failed to dereference property {propName} for alias {varName}, Entity type {entField.BoundEntityName} does not have a property named {propName}");
-                            }
-                            entField.AddReferenceFieldName(propName);
-                            prop.DataType = entPropField.FieldType;
-                        }
-                    }
-
-                    // do data type evaluation
                     var evalutedType = map.Value.Expr.EvaluateType();
                     var outField = map.Value.Field as ValueField;
                     outField.FieldType = evalutedType;

--- a/src/LogicalPlanner/Logical/SelectionOperator.cs
+++ b/src/LogicalPlanner/Logical/SelectionOperator.cs
@@ -138,6 +138,15 @@ namespace openCypherTranspiler.LogicalPlanner
                             };
                     });
             }
+
+            // Update in-place for property references inside FilterExpression
+            if (FilterExpression != null)
+            {
+                foreach (var prop in FilterExpression.GetChildrenOfType<QueryExpressionProperty>())
+                {
+                    UpdatePropertyBasedOnAliasFromInputSchema(prop);
+                }
+            }
         }
 
         internal override void AppendReferencedProperties(IDictionary<string, EntityField> entityFields)
@@ -194,7 +203,7 @@ namespace openCypherTranspiler.LogicalPlanner
                     // field member access (i.e. [VariableName].[fieldName]), just append to list
                     if (!entityFields.ContainsKey(varName))
                     {
-                        throw new TranspilerSyntaxErrorException($"Failed to access member '{fieldName} for '{varName}' which does not exist");
+                        throw new TranspilerSyntaxErrorException($"Failed to access member '{fieldName}' for '{varName}' which does not exist");
                     }
                     var entity = entityFields[varName];
                     entity.AddReferenceFieldName(fieldName);

--- a/src/openCypherParser/AST/CypherVisitor.cs
+++ b/src/openCypherParser/AST/CypherVisitor.cs
@@ -781,7 +781,7 @@ namespace openCypherTranspiler.openCypherParser.AST
             var entitiesInFinalReturn = GetDirectlyExposedEntitiesWithAliasApplied(singleQuery.EntityPropertySelected);
             if (entitiesInFinalReturn.Count() > 0)
             {
-                throw new TranspilerNotSupportedException($"Entities ({string.Join(", ", entitiesInFinalReturn.Select(e => e.Alias))}) in return statement");
+                throw new TranspilerNotSupportedException($"Returning the whole entity '{entitiesInFinalReturn.Select(e => e.Alias).First()}' instead of its properties");
             }
 
             return singleQuery;

--- a/src/openCypherParser/AST/Expressions/QueryExpressionBinary.cs
+++ b/src/openCypherParser/AST/Expressions/QueryExpressionBinary.cs
@@ -49,8 +49,8 @@ namespace openCypherTranspiler.openCypherParser.AST
                 case BinaryOperatorType.Logical:
                     // For logical comparison, we ensure that all operands' type are logical already
                     // The return type is always boolean (logical)
-                    if (leftType != typeof(bool) || leftType != typeof(bool?) &&
-                    rightType != typeof(bool) || rightType != typeof(bool?))
+                    if ((leftType != typeof(bool) && leftType != typeof(bool?)) ||
+                        (rightType != typeof(bool) && rightType != typeof(bool?)) )
                     {
                         throw new TranspilerNotSupportedException($"Logical binary operator {Operator} operating must operate on bool types. Actual types: {leftType}, {rightType}");
                     }

--- a/src/openCypherParser/AST/Expressions/QueryExpressionBinary.cs
+++ b/src/openCypherParser/AST/Expressions/QueryExpressionBinary.cs
@@ -74,12 +74,22 @@ namespace openCypherTranspiler.openCypherParser.AST
                     {
                         if (!TypeCoersionTables.CoersionTableEqualityComparison.TryGetValue((leftTypeUnboxed, rightTypeUnboxed), out resultedTypeRaw))
                         {
-                            throw new TranspilerInternalErrorException($"Unexpected use of binary operator {Operator.Name} operating between types {leftTypeUnboxed} and {rightTypeUnboxed}");
+                            throw new TranspilerInternalErrorException($"Unexpected use of (un)equality operator {Operator.Name} operating between types {leftTypeUnboxed} and {rightTypeUnboxed}");
                         }
+                    }
+                    else if (Operator.Name == BinaryOperator.IN)
+                    {
+                        // IN need special handling as right operand is a list
+                        var innerTypes = rightTypeUnboxed.GetGenericArguments();
+                        if (innerTypes == null || innerTypes.Length != 1)
+                        {
+                            throw new TranspilerInternalErrorException($"Unexpected use of IN operator, the right type {rightTypeUnboxed} is not a list of value type");
+                        }
+                        resultedTypeRaw = typeof(bool);
                     }
                     else
                     {
-                        if (!TypeCoersionTables.CoersionTableInequalityComparison.TryGetValue((leftTypeUnboxed, rightTypeUnboxed), out resultedTypeRaw))
+                        if (!TypeCoersionTables.CoersionTableDefaultComparison.TryGetValue((leftTypeUnboxed, rightTypeUnboxed), out resultedTypeRaw))
                         {
                             throw new TranspilerInternalErrorException($"Unexpected use of binary operator {Operator.Name} operating between types {leftTypeUnboxed} and {rightTypeUnboxed}");
                         }

--- a/src/openCypherParser/AST/LookupTables/TypeCoersionTables.cs
+++ b/src/openCypherParser/AST/LookupTables/TypeCoersionTables.cs
@@ -1394,7 +1394,7 @@ namespace openCypherTranspiler.openCypherParser.AST
             { (typeof(bool), typeof(bool)), typeof(bool) },
         };
 
-        public static readonly IDictionary<(Type O1Type, Type O2Type), Type> CoersionTableInequalityComparison = new Dictionary<(Type Op1Type, Type Op2Type), Type>()
+        public static readonly IDictionary<(Type O1Type, Type O2Type), Type> CoersionTableDefaultComparison = new Dictionary<(Type Op1Type, Type Op2Type), Type>()
         {
             { (typeof(int), typeof(int)), typeof(bool) },
             { (typeof(int), typeof(double)), typeof(bool) },

--- a/tests/CommonTest/JSONGraphSchema.cs
+++ b/tests/CommonTest/JSONGraphSchema.cs
@@ -87,22 +87,12 @@ namespace openCypherTranspiler.CommonTest
 
         public EdgeSchema GetEdgeDefinition(string edgeVerb, string fromNodeName, string toNodeName)
         {
-            var edge = _allEdgeDefinions?.Where(n => n.Name == edgeVerb && n.SourceNodeId == fromNodeName && n.SinkNodeId == toNodeName).FirstOrDefault();
-            if (edge == null)
-            {
-                throw new KeyNotFoundException($"Edge with edgeverb = {edgeVerb}, fromNodeName = {fromNodeName} and toNodename = {toNodeName} not found!");
-            }
-            return edge;
+            return _allEdgeDefinions?.Where(n => n.Name == edgeVerb && n.SourceNodeId == fromNodeName && n.SinkNodeId == toNodeName).FirstOrDefault();
         }
 
         public NodeSchema GetNodeDefinition(string nodeName)
         {
-            var node = _allNodeDefinions?.Where(n => n.Name == nodeName).FirstOrDefault();
-            if (node == null)
-            {
-                throw new KeyNotFoundException($"Node with name = {nodeName} not found!");
-            }
-            return node;
+            return _allNodeDefinions?.Where(n => n.Name == nodeName).FirstOrDefault();
         }
         
     }

--- a/tests/SQLRenderer.Test/SQLRendererTest.cs
+++ b/tests/SQLRenderer.Test/SQLRendererTest.cs
@@ -733,6 +733,13 @@ return p.Name as Name, m.Title as Title
     ";
                 RunQueryAndCompare(queryText);
             }
+            {
+                var queryText = @"
+MATCH (m:Movie)-[:DIRECTED]-(p:Person)
+return p.Name as Name, m.Title as Title
+    ";
+                RunQueryAndCompare(queryText);
+            }
 
             // negative test case (wrong direction)
             {

--- a/tests/SQLRenderer.Test/SQLRendererTest.cs
+++ b/tests/SQLRenderer.Test/SQLRendererTest.cs
@@ -605,7 +605,7 @@ RETURN  Title, Name
                 var queryText = @"
 MATCH (p:Person)-[:ACTED_IN]-(m:Movie)
 WHERE p.Name in ['Tom Hanks', 'Meg Ryan'] and m.Released >= 1990
-RETURN p.Name as Name, m.Title AS Title, m.Released % 100 as ReleasedYear2Digit, m.Released - 2000 as YearSinceY2k, m.Released * 1 / 1 ^ 1 AS TestReleasedYear
+RETURN p.Name as Name, p.Name in ['Tom Hanks', 'Meg Ryan'] as NameChecksOut, m.Title AS Title, m.Released % 100 as ReleasedYear2Digit, m.Released - 2000 as YearSinceY2k, m.Released * 1 / 1 ^ 1 AS TestReleasedYear
 ";
 
                 RunQueryAndCompare(queryText);

--- a/tests/SQLRenderer.Test/SQLRendererTest.cs
+++ b/tests/SQLRenderer.Test/SQLRendererTest.cs
@@ -565,9 +565,9 @@ RETURN Title, Name
     ";
                     TranspileToSQL(queryText);
                 }
-                catch (TranspilerSyntaxErrorException e)
+                catch (TranspilerBindingException e)
                 {
-                    Assert.IsTrue(e.Message.Contains("'a' which does not exist"));
+                    Assert.IsTrue(e.Message.Contains("Alias 'a' does not exist in the current context"));
                     expectedExceptionThrown = true;
                 }
                 Assert.IsTrue(expectedExceptionThrown);
@@ -587,9 +587,9 @@ RETURN  Title, Name
     ";
                     TranspileToSQL(queryText);
                 }
-                catch (TranspilerSyntaxErrorException e)
+                catch (TranspilerBindingException e)
                 {
-                    Assert.IsTrue(e.Message.Contains("'TitleNotExist' does not exist"));
+                    Assert.IsTrue(e.Message.Contains("Alias 'TitleNotExist' does not exist in the current context"));
                     expectedExceptionThrown = true;
                 }
                 Assert.IsTrue(expectedExceptionThrown);


### PR DESCRIPTION
fixes some issues propagating data types during logic planning
type are propagated/evaluated in WHERE condition expressions as well
change the behavior that non-existent edge/node from graph provider would result in keyvaluenotfound exception: it will return null instead